### PR TITLE
Increase test coverage, add isort

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ for basic authentication will set the proper
   - [Signed Search Key](https://www.elastic.co/guide/en/app-search/current/authentication.html#authentication-signed)
   - [URL Parameters](https://www.elastic.co/guide/en/app-search/current/authentication.html#authentication-url-params)
 - Workplace Search
-  - [Custom Source API Key](https://www.elastic.co/guide/en/workplace-search/7.8/workplace-search-custom-sources-api.html#authentication)
+  - [Custom Source API Key](https://www.elastic.co/guide/en/workplace-search/current/workplace-search-custom-sources-api.html#authentication)
   - [OAuth for Search](https://www.elastic.co/guide/en/workplace-search/current/building-custom-search-workplace-search.html#configuring-search-oauth)
 
 #### Authenticating with Enterprise Search
@@ -140,6 +140,32 @@ resp = client_side.search(
     }
 )
 ```
+
+### Working with Datetimes
+
+Python [`datetime.datetime`](https://docs.python.org/3/library/datetime.html#datetime.datetime)
+objects are automatically serialized according to [RFC 3339](https://tools.ietf.org/html/rfc3339)
+which requires a timezone to be included. We highly recommend using datetimes that
+are timezone-aware. When creating a datetime object, use the `tzinfo` or `tz` parameter
+along with [`python-dateutil`](https://dateutil.readthedocs.io) to ensure proper
+timezones on serialized `datetime` objects.
+
+To get the current day and time in UTC you can do the following:
+
+```python
+import datetime
+from dateutil import tz
+
+now = datetime.datetime.now(tz=tz.UTC)
+```
+
+⚠️ **Datetimes without timezone information will be serialized as if they were within
+the locally configured timezone.** This is in line with HTTP and RFC 3339 specs
+which state that datetimes without timezone information should be assumed to be local time.
+
+⚠️ [**Do not use `datetime.datetime.utcnow()` or `utcfromtimestamp()`!**](https://blog.ganssle.io/articles/2019/11/utcnow.html)
+These APIs don't add timezone information to the resulting datetime which causes the
+serializer to return incorrect results.
 
 ## API Reference
 
@@ -784,7 +810,7 @@ Parameters:
 Get information on the health of a deployment and basic statistics around
 resource usage
 
-
+Parameters:
 - `params`: Additional query params to send with the request
 - `headers`: Additional headers to send with the request
 - `http_auth`: Access token or HTTP basic auth username
@@ -794,7 +820,7 @@ resource usage
 
 Get the read-only flag's state
 
-
+Parameters:
 - `params`: Additional query params to send with the request
 - `headers`: Additional headers to send with the request
 - `http_auth`: Access token or HTTP basic auth username
@@ -827,7 +853,7 @@ Parameters:
 
 Get version information for this server
 
-
+Parameters:
 - `params`: Additional query params to send with the request
 - `headers`: Additional headers to send with the request
 - `http_auth`: Access token or HTTP basic auth username
@@ -837,18 +863,5 @@ Get version information for this server
 
 ## License
 
-```
-Copyright 2020 Elasticsearch B.V
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-```
+`enterprise-search-python` is available under the Apache-2.0 license.
+For more details see [LICENSE](https://github.com/elastic/enterprise-search-python/blob/maaster/LICENSE).

--- a/elastic_enterprise_search/__init__.py
+++ b/elastic_enterprise_search/__init__.py
@@ -19,27 +19,28 @@
 
 from elastic_transport import (
     APIError,
-    BadRequestError,
     BadGatewayError,
-    PaymentRequiredError,
-    UnauthorizedError,
-    ServiceUnavailableError,
+    BadRequestError,
+    ConflictError,
+    ConnectionError,
+    ConnectionTimeout,
+    ForbiddenError,
+    GatewayTimeoutError,
     InternalServerError,
     MethodNotImplementedError,
     NotFoundError,
-    ForbiddenError,
-    GatewayTimeoutError,
-    ConflictError,
-    SerializationError,
-    RetriesExhausted,
-    ConnectionError,
-    ConnectionTimeout,
-    TransportError,
     PayloadTooLargeError,
+    PaymentRequiredError,
+    RetriesExhausted,
+    SerializationError,
+    ServiceUnavailableError,
+    TransportError,
+    UnauthorizedError,
 )
+
+from ._version import __version__  # noqa: F401
 from .client import AppSearch, EnterpriseSearch, WorkplaceSearch
 from .serializer import JSONSerializer
-from ._version import __version__  # noqa: F401
 from .utils import parse_datetime
 
 __all__ = [

--- a/elastic_enterprise_search/client/__init__.py
+++ b/elastic_enterprise_search/client/__init__.py
@@ -17,6 +17,7 @@
 
 import jwt
 from six import ensure_str
+
 from .app_search import AppSearch as _AppSearch
 from .enterprise_search import EnterpriseSearch as _EnterpriseSearch
 from .workplace_search import WorkplaceSearch as _WorkplaceSearch

--- a/elastic_enterprise_search/client/app_search.py
+++ b/elastic_enterprise_search/client/app_search.py
@@ -15,13 +15,8 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+from ..utils import DEFAULT, SKIP_IN_PATH, make_params, make_path  # noqa: F401
 from .base import BaseClient
-from ..utils import (  # noqa: F401
-    make_path,
-    make_params,
-    DEFAULT,
-    SKIP_IN_PATH,
-)
 
 
 class AppSearch(BaseClient):

--- a/elastic_enterprise_search/client/base.py
+++ b/elastic_enterprise_search/client/base.py
@@ -16,13 +16,14 @@
 #  under the License.
 
 import base64
-from six import ensure_str, ensure_binary, ensure_text
+
+from elastic_transport import Transport
+from elastic_transport.utils import create_user_agent, normalize_headers
+from six import ensure_binary, ensure_str, ensure_text
+
 from .._version import __version__
 from ..serializer import JSONSerializer
 from ..utils import DEFAULT
-from elastic_transport import Transport
-from elastic_transport.utils import normalize_headers, create_user_agent
-
 
 __all__ = ["BaseClient"]
 
@@ -37,9 +38,12 @@ class BaseClient(object):
         **kwargs
     ):
         if _transport is not None:
-            if transport_class is not None or kwargs:
+            if (
+                any(x is not None for x in (hosts, http_auth, transport_class))
+                or kwargs
+            ):
                 raise ValueError(
-                    "Can't pass both a Transport and parameters to a client"
+                    "Can't pass both a Transport via '_transport' and other parameters a client constructor"
                 )
             self.transport = _transport
         else:
@@ -77,7 +81,7 @@ class BaseClient(object):
                     b64_encoded = ensure_binary(auth_header.partition(" ")[-1])
                     b64_decoded = ensure_text(base64.b64decode(b64_encoded))
                     return tuple(b64_decoded.split(":", 1))
-                except Exception:
+                except Exception:  # pragma: nocover
                     pass
             return auth_header.partition(" ")[-1]
         return None

--- a/elastic_enterprise_search/client/enterprise_search.py
+++ b/elastic_enterprise_search/client/enterprise_search.py
@@ -15,13 +15,8 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+from ..utils import DEFAULT, SKIP_IN_PATH, make_params, make_path  # noqa: F401
 from .base import BaseClient
-from ..utils import (  # noqa: F401
-    make_path,
-    make_params,
-    DEFAULT,
-    SKIP_IN_PATH,
-)
 
 
 class EnterpriseSearch(BaseClient):

--- a/elastic_enterprise_search/client/workplace_search.py
+++ b/elastic_enterprise_search/client/workplace_search.py
@@ -15,13 +15,8 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+from ..utils import DEFAULT, SKIP_IN_PATH, make_params, make_path  # noqa: F401
 from .base import BaseClient
-from ..utils import (  # noqa: F401
-    make_path,
-    make_params,
-    DEFAULT,
-    SKIP_IN_PATH,
-)
 
 
 class WorkplaceSearch(BaseClient):

--- a/elastic_enterprise_search/utils.py
+++ b/elastic_enterprise_search/utils.py
@@ -18,10 +18,11 @@
 import re
 import sys
 from datetime import date, datetime
-from six import ensure_binary
-from six.moves.urllib_parse import urlencode, urlparse, unquote, quote
-from dateutil import tz, parser
+
+from dateutil import parser, tz
 from elastic_transport.utils import DEFAULT as DEFAULT
+from six import ensure_binary
+from six.moves.urllib_parse import quote, unquote, urlencode, urlparse
 
 __all__ = [
     "urlparse",
@@ -115,7 +116,7 @@ def format_datetime(value):
     """Format a datetime object to RFC 3339"""
     # When given a timezone unaware datetime, use local timezone.
     if value.tzinfo is None:
-        value = value.astimezone(tz.tzlocal())
+        value = value.replace(tzinfo=tz.tzlocal())
 
     utcoffset = value.utcoffset()
     offset_secs = utcoffset.total_seconds()
@@ -133,7 +134,10 @@ def format_datetime(value):
 
 def parse_datetime(value):
     """Convert a string value RFC 3339 into a datetime with tzinfo"""
-    if not re.match(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}[T ]Z|[+\-][0-9]{2}:[0-9]{2}$", value):
+    if not re.match(
+        r"^[0-9]{4}-[0-9]{2}-[0-9]{2}[T ][0-9]{2}:[0-9]{2}:[0-9]{2}(?:Z|[+\-][0-9]{2}:[0-9]{2})$",
+        value,
+    ):
         raise ValueError(
             "Datetime must match format '(YYYY)-(MM)-(DD)T(HH):(MM):(SS)(TZ)' was '%s'"
             % value

--- a/noxfile.py
+++ b/noxfile.py
@@ -15,9 +15,9 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-from os.path import join, abspath, dirname
-import nox
+from os.path import abspath, dirname, join
 
+import nox
 
 SOURCE_FILES = (
     "noxfile.py",
@@ -29,11 +29,12 @@ SOURCE_FILES = (
 
 
 @nox.session()
-def blacken(session):
-    session.install("black")
+def format(session):
+    session.install("black", "isort")
     session.run(
         "black", "--target-version=py27", "--target-version=py37", *SOURCE_FILES
     )
+    session.run("isort", *SOURCE_FILES)
     session.run("python", "utils/license-headers.py", "fix", *SOURCE_FILES)
 
     lint(session)
@@ -41,7 +42,7 @@ def blacken(session):
 
 @nox.session
 def lint(session):
-    session.install("flake8", "black")
+    session.install("flake8", "black", "isort")
     session.run(
         "black",
         "--check",
@@ -49,6 +50,7 @@ def lint(session):
         "--target-version=py37",
         *SOURCE_FILES
     )
+    session.run("isort", "--check", *SOURCE_FILES)
     session.run("flake8", "--ignore=E501,W503", *SOURCE_FILES)
     session.run("python", "utils/license-headers.py", "check", *SOURCE_FILES)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [bdist_wheel]
 universal = 1
+
+[isort]
+profile = black

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@
 
 import os
 import re
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
 
 base_dir = os.path.dirname(os.path.abspath(__file__))
 with open(os.path.join(base_dir, "elastic_enterprise_search/_version.py")) as f:

--- a/tests/client/test_app_search.py
+++ b/tests/client/test_app_search.py
@@ -16,6 +16,7 @@
 #  under the License.
 
 import jwt
+
 from elastic_enterprise_search import AppSearch
 
 

--- a/tests/client/test_enterprise_search.py
+++ b/tests/client/test_enterprise_search.py
@@ -15,7 +15,7 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-from elastic_enterprise_search import EnterpriseSearch, AppSearch, WorkplaceSearch
+from elastic_enterprise_search import AppSearch, EnterpriseSearch, WorkplaceSearch
 
 
 def test_sub_clients():

--- a/tests/client/test_options.py
+++ b/tests/client/test_options.py
@@ -16,8 +16,22 @@
 #  under the License.
 
 import pytest
-from tests.conftest import DummyConnection
+from elastic_transport import Transport
+
 from elastic_enterprise_search import EnterpriseSearch
+from tests.conftest import DummyConnection
+
+
+@pytest.mark.parametrize(
+    "option", ["hosts", "http_auth", "transport_class", "connection_class"]
+)
+def test_transport_constructor(client_class, option):
+    with pytest.raises(ValueError) as e:
+        client_class(_transport=Transport(), **{option: True})
+    assert str(e.value) == (
+        "Can't pass both a Transport via '_transport' "
+        "and other parameters a client constructor"
+    )
 
 
 @pytest.mark.parametrize("request_timeout", [3, 5.0])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,11 +17,8 @@
 
 import pytest
 from elastic_transport import Connection
-from elastic_enterprise_search import (
-    EnterpriseSearch,
-    AppSearch,
-    WorkplaceSearch,
-)
+
+from elastic_enterprise_search import AppSearch, EnterpriseSearch, WorkplaceSearch
 
 
 @pytest.fixture(params=[EnterpriseSearch, AppSearch, WorkplaceSearch])

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -17,6 +17,7 @@
 
 import pytest
 import urllib3
+
 from elastic_enterprise_search import EnterpriseSearch
 
 

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -17,19 +17,30 @@
 
 import datetime
 
-from elastic_transport import JSONSerializer as _JSONSerializer
+from dateutil import tz
 
-from .utils import format_datetime
+from elastic_enterprise_search import JSONSerializer
 
 
-class JSONSerializer(_JSONSerializer):
-    """Same as elastic_transport.JSONSerializer except also formats
-    datetime objects to RFC 3339. If a datetime is received without
-    explicit timezone information then the timezone will be assumed
-    to be the local timezone.
-    """
-
-    def default(self, data):
-        if isinstance(data, datetime.datetime):
-            return format_datetime(data)
-        return super(JSONSerializer, self).default(data)
+def test_serializer_formatting():
+    serializer = JSONSerializer()
+    assert (
+        serializer.dumps(
+            {
+                "d": datetime.datetime(
+                    year=2020,
+                    month=12,
+                    day=11,
+                    hour=10,
+                    minute=9,
+                    second=8,
+                    tzinfo=tz.UTC,
+                ),
+            }
+        )
+        == '{"d":"2020-12-11T10:09:08Z"}'
+    )
+    assert (
+        serializer.dumps({"t": datetime.date(year=2020, month=1, day=29)})
+        == '{"t":"2020-01-29"}'
+    )

--- a/utils/generator/generate-api.py
+++ b/utils/generator/generate-api.py
@@ -15,11 +15,12 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-import os
-import re
 import json
+import os
 import pathlib
-from typing import Optional, List
+import re
+from typing import List, Optional
+
 import jinja2
 
 base_dir = pathlib.Path(__file__).absolute().parent.parent.parent

--- a/utils/license-headers.py
+++ b/utils/license-headers.py
@@ -22,9 +22,8 @@ error out if 'fix' would have changed the file.
 
 import os
 import sys
-from typing import List, Iterator
 from itertools import chain
-
+from typing import Iterator, List
 
 lines_to_keep = ["# -*- coding: utf-8 -*-\n", "#!/usr/bin/env python\n"]
 license_header_lines = [


### PR DESCRIPTION
- Documents how to work with datetime objects
- Adds `isort` to keep imports sorted automatically
- Increases test coverage of all non-client modules