### PR TITLE
Fix create_synonyms_set not working

### DIFF
--- a/elastic_enterprise_search/client/_app_search.py
+++ b/elastic_enterprise_search/client/_app_search.py
@@ -1395,12 +1395,6 @@ class AppSearch(BaseClient):
             if param in SKIP_IN_PATH:
                 raise ValueError("Empty value passed for a required argument")
 
-        params = make_params(
-            params,
-            {
-                "synonyms": synonyms,
-            },
-        )
         return self.perform_request(
             "POST",
             make_path(
@@ -1411,6 +1405,7 @@ class AppSearch(BaseClient):
                 engine_name,
                 "synonyms",
             ),
+            body={"synonyms": synonyms},
             params=params,
             headers=headers,
             http_auth=http_auth,


### PR DESCRIPTION
According to the [documentation](https://www.elastic.co/guide/en/app-search/current/synonyms.html#synonyms-create), `create_synonyms_set` should send a body containing the synonyms list. Currently, the code is sending it as a URL parameter, which fails. This PR, fixes the issue by sending the synonyms list through the body.