### PR TITLE
Use 'x-codegen-request-body-name' parameter for named scalar bodies

### DIFF
--- a/docs/guide/app-search-api.asciidoc
+++ b/docs/guide/app-search-api.asciidoc
@@ -154,7 +154,7 @@ with the `index_documents()` method:
 # Request:
 app_search.index_documents(
     engine_name="national-parks",
-    body=[{
+    documents=[{
         "id": "park_rocky-mountain",
         "title": "Rocky Mountain",
         "nps_link": "https://www.nps.gov/romo/index.htm",
@@ -256,7 +256,7 @@ the `get_documents()` method:
 # Request:
 app_search.get_documents(
     engine_name="national-parks",
-    body=["park_rocky-mountain"]
+    document_ids=["park_rocky-mountain"]
 )
 
 # Response:
@@ -286,7 +286,7 @@ You can update documents with the `put_documents()` method:
 # Request:
 resp = app_search.put_documents(
     engine_name="national-parks",
-    body=[{
+    documents=[{
         "id": "park_rocky-mountain",
         "visitors": 10000000
     }]
@@ -310,7 +310,7 @@ You can delete documents from an Engine with the `delete_documents()` method:
 # Request:
 resp = app_search.delete_documents(
     engine_name="national-parks",
-    body=["park_rocky-mountain"]
+    document_ids=["park_rocky-mountain"]
 )
 
 # Response:
@@ -362,7 +362,7 @@ as a `date` as desired. Update the type of the `date_established` field:
 # Request:
 resp = app_search.put_schema(
     engine_name="national-parks",
-    body={
+    schema={
         "date_established": "date"
     }
 )
@@ -642,7 +642,7 @@ we can add additional Source Engines to it with the
 # Request:
 app_search.add_meta_engine_source(
     engine_name="meta-engine",
-    body=["state-parks"]
+    source_engines=["state-parks"]
 )
 
 # Response:
@@ -667,7 +667,7 @@ If we change our mind about `state-parks` being a Source Engine for
 # Request:
 app_search.delete_meta_engine_source(
     engine_name="meta-engine",
-    body=["state-parks"]
+    source_engines=["state-parks"]
 )
 
 # Response:

--- a/elastic_enterprise_search/client/_app_search.py
+++ b/elastic_enterprise_search/client/_app_search.py
@@ -450,7 +450,7 @@ class AppSearch(BaseClient):
     def delete_documents(
         self,
         engine_name,
-        body,
+        document_ids,
         params=None,
         headers=None,
         http_auth=DEFAULT,
@@ -463,7 +463,7 @@ class AppSearch(BaseClient):
         `<https://www.elastic.co/guide/en/app-search/current/documents.html#documents-delete>`_
 
         :arg engine_name: Name of the engine
-        :arg body: List of document IDs
+        :arg document_ids: List of document IDs
         :arg params: Additional query params to send with the request
         :arg headers: Additional headers to send with the request
         :arg http_auth: Access token or HTTP basic auth username
@@ -486,7 +486,7 @@ class AppSearch(BaseClient):
                 engine_name,
                 "documents",
             ),
-            body=body,
+            body=document_ids,
             params=params,
             headers=headers,
             http_auth=http_auth,
@@ -497,7 +497,7 @@ class AppSearch(BaseClient):
     def get_documents(
         self,
         engine_name,
-        body,
+        document_ids,
         params=None,
         headers=None,
         http_auth=DEFAULT,
@@ -510,7 +510,7 @@ class AppSearch(BaseClient):
         `<https://www.elastic.co/guide/en/app-search/current/documents.html#documents-get>`_
 
         :arg engine_name: Name of the engine
-        :arg body: List of document IDs
+        :arg document_ids: List of document IDs
         :arg params: Additional query params to send with the request
         :arg headers: Additional headers to send with the request
         :arg http_auth: Access token or HTTP basic auth username
@@ -533,7 +533,7 @@ class AppSearch(BaseClient):
                 engine_name,
                 "documents",
             ),
-            body=body,
+            body=document_ids,
             params=params,
             headers=headers,
             http_auth=http_auth,
@@ -544,7 +544,7 @@ class AppSearch(BaseClient):
     def index_documents(
         self,
         engine_name,
-        body,
+        documents,
         params=None,
         headers=None,
         http_auth=DEFAULT,
@@ -557,7 +557,7 @@ class AppSearch(BaseClient):
         `<https://www.elastic.co/guide/en/app-search/current/documents.html#documents-create>`_
 
         :arg engine_name: Name of the engine
-        :arg body: List of document to index
+        :arg documents: List of document to index
         :arg params: Additional query params to send with the request
         :arg headers: Additional headers to send with the request
         :arg http_auth: Access token or HTTP basic auth username
@@ -580,7 +580,7 @@ class AppSearch(BaseClient):
                 engine_name,
                 "documents",
             ),
-            body=body,
+            body=documents,
             params=params,
             headers=headers,
             http_auth=http_auth,
@@ -644,7 +644,7 @@ class AppSearch(BaseClient):
     def put_documents(
         self,
         engine_name,
-        body,
+        documents,
         params=None,
         headers=None,
         http_auth=DEFAULT,
@@ -657,7 +657,7 @@ class AppSearch(BaseClient):
         `<https://www.elastic.co/guide/en/app-search/current/documents.html#documents-partial>`_
 
         :arg engine_name: Name of the engine
-        :arg body: List of documents to update
+        :arg documents: List of documents to update
         :arg params: Additional query params to send with the request
         :arg headers: Additional headers to send with the request
         :arg http_auth: Access token or HTTP basic auth username
@@ -680,7 +680,7 @@ class AppSearch(BaseClient):
                 engine_name,
                 "documents",
             ),
-            body=body,
+            body=documents,
             params=params,
             headers=headers,
             http_auth=http_auth,
@@ -938,7 +938,7 @@ class AppSearch(BaseClient):
     def add_meta_engine_source(
         self,
         engine_name,
-        body,
+        source_engines,
         params=None,
         headers=None,
         http_auth=DEFAULT,
@@ -951,7 +951,7 @@ class AppSearch(BaseClient):
         `<https://www.elastic.co/guide/en/app-search/current/meta-engines.html#meta-engines-add-source-engines>`_
 
         :arg engine_name: Name of the engine
-        :arg body: List of engine IDs
+        :arg source_engines: List of engine IDs
         :arg params: Additional query params to send with the request
         :arg headers: Additional headers to send with the request
         :arg http_auth: Access token or HTTP basic auth username
@@ -974,7 +974,7 @@ class AppSearch(BaseClient):
                 engine_name,
                 "source_engines",
             ),
-            body=body,
+            body=source_engines,
             params=params,
             headers=headers,
             http_auth=http_auth,
@@ -985,7 +985,7 @@ class AppSearch(BaseClient):
     def delete_meta_engine_source(
         self,
         engine_name,
-        body,
+        source_engines,
         params=None,
         headers=None,
         http_auth=DEFAULT,
@@ -998,7 +998,7 @@ class AppSearch(BaseClient):
         `<https://www.elastic.co/guide/en/app-search/current/meta-engines.html#meta-engines-remove-source-engines>`_
 
         :arg engine_name: Name of the engine
-        :arg body: List of engine IDs
+        :arg source_engines: List of engine IDs
         :arg params: Additional query params to send with the request
         :arg headers: Additional headers to send with the request
         :arg http_auth: Access token or HTTP basic auth username
@@ -1021,7 +1021,7 @@ class AppSearch(BaseClient):
                 engine_name,
                 "source_engines",
             ),
-            body=body,
+            body=source_engines,
             params=params,
             headers=headers,
             http_auth=http_auth,
@@ -1192,7 +1192,7 @@ class AppSearch(BaseClient):
     def put_schema(
         self,
         engine_name,
-        body,
+        schema,
         params=None,
         headers=None,
         http_auth=DEFAULT,
@@ -1205,7 +1205,7 @@ class AppSearch(BaseClient):
         `<https://www.elastic.co/guide/en/app-search/current/schema.html#schema-patch>`_
 
         :arg engine_name: Name of the engine
-        :arg body: Schema description
+        :arg schema: Schema description
         :arg params: Additional query params to send with the request
         :arg headers: Additional headers to send with the request
         :arg http_auth: Access token or HTTP basic auth username
@@ -1228,7 +1228,7 @@ class AppSearch(BaseClient):
                 engine_name,
                 "schema",
             ),
-            body=body,
+            body=schema,
             params=params,
             headers=headers,
             http_auth=http_auth,

--- a/tests/client/app_search/test_app_search.py
+++ b/tests/client/app_search/test_app_search.py
@@ -88,7 +88,7 @@ def test_list_documents(app_search):
 def test_delete_documents(app_search):
     resp = app_search.delete_documents(
         engine_name="national-parks-demo",
-        body=[
+        document_ids=[
             "park_yellowstone",
             "park_zion",
         ],
@@ -104,7 +104,7 @@ def test_delete_documents(app_search):
 def test_index_documents(app_search):
     resp = app_search.index_documents(
         engine_name="national-parks-demo",
-        body=[
+        documents=[
             {
                 "nps_link": "https://www.nps.gov/zion/index.htm",
                 "title": "Zion",
@@ -276,7 +276,7 @@ def test_meta_engine(app_search):
     # Use the add_meta_engine_source() API
     app_search.create_engine(engine_name="source-engine-added")
     resp = app_search.add_meta_engine_source(
-        engine_name="meta-engine", body=["source-engine-added"]
+        engine_name="meta-engine", source_engines=["source-engine-added"]
     )
     assert resp.status == 200
     assert resp == {

--- a/tests/client/enterprise_search/__init__.py
+++ b/tests/client/enterprise_search/__init__.py
@@ -1,0 +1,16 @@
+#  Licensed to Elasticsearch B.V. under one or more contributor
+#  license agreements. See the NOTICE file distributed with
+#  this work for additional information regarding copyright
+#  ownership. Elasticsearch B.V. licenses this file to you under
+#  the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.

--- a/tests/client/enterprise_search/cassettes/test_get_and_put_read_only.yaml
+++ b/tests/client/enterprise_search/cassettes/test_get_and_put_read_only.yaml
@@ -1,0 +1,122 @@
+interactions:
+- request:
+    body: '{"enabled":true}'
+    headers:
+      authorization:
+      - Basic ZWxhc3RpYzpjaGFuZ2VtZQ==
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+    method: PUT
+    uri: http://localhost:3002/api/ent/v1/internal/read_only_mode
+  response:
+    body:
+      string: '{"enabled":true}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json;charset=utf-8
+      ETag:
+      - W/"ebd28baaaa212dca587bc607653bbaf0"
+      Server:
+      - Jetty(9.4.33.v20201020)
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding, User-Agent
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - 788bdbb8-5b4e-4033-8a53-9f50ab9a309f
+      X-Runtime:
+      - '0.023845'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      authorization:
+      - Basic ZWxhc3RpYzpjaGFuZ2VtZQ==
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+    method: GET
+    uri: http://localhost:3002/api/ent/v1/internal/read_only_mode
+  response:
+    body:
+      string: '{"enabled":true}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json;charset=utf-8
+      ETag:
+      - W/"ebd28baaaa212dca587bc607653bbaf0"
+      Server:
+      - Jetty(9.4.33.v20201020)
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding, User-Agent
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - 4be35df3-e551-48f7-8dfa-bd291a4f75bd
+      X-Runtime:
+      - '0.023486'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"enabled":false}'
+    headers:
+      authorization:
+      - Basic ZWxhc3RpYzpjaGFuZ2VtZQ==
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+    method: PUT
+    uri: http://localhost:3002/api/ent/v1/internal/read_only_mode
+  response:
+    body:
+      string: '{"enabled":false}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json;charset=utf-8
+      ETag:
+      - W/"d987f50e402ceb8f1a41643a6c665ef0"
+      Server:
+      - Jetty(9.4.33.v20201020)
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding, User-Agent
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - f226e990-69cf-46fa-a8ab-f7f8791b1c9e
+      X-Runtime:
+      - '0.213871'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/client/enterprise_search/cassettes/test_get_health.yaml
+++ b/tests/client/enterprise_search/cassettes/test_get_health.yaml
@@ -1,0 +1,46 @@
+interactions:
+- request:
+    body: null
+    headers:
+      authorization:
+      - Basic ZWxhc3RpYzpjaGFuZ2VtZQ==
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+    method: GET
+    uri: http://localhost:3002/api/ent/v1/internal/health
+  response:
+    body:
+      string: '{"name":"f1b653d1bbd8","version":{"number":"7.12.0","build_hash":"3a6edf8029dd285b60f1a6d63c741f46df7f195f","build_date":"2021-01-06T15:24:44Z"},"jvm":{"gc":{"collection_count":43,"collection_time":2360,"garbage_collectors":{"PS
+        Scavenge":{"collection_count":38,"collection_time":1095},"PS MarkSweep":{"collection_count":5,"collection_time":1265}}},"pid":6,"uptime":5017178,"memory_usage":{"heap_init":1073741824,"heap_used":494383704,"heap_committed":1803026432,"heap_max":1908932608,"object_pending_finalization_count":0,"non_heap_init":2555904,"non_heap_committed":365125632},"memory_pools":["Code
+        Cache","Metaspace","Compressed Class Space","PS Eden Space","PS Survivor Space","PS
+        Old Gen"],"threads":{"thread_count":38,"peak_thread_count":45,"total_started_thread_count":154,"daemon_thread_count":12},"vm_version":"25.252-b09","vm_vendor":"AdoptOpenJDK","vm_name":"OpenJDK
+        64-Bit Server VM"},"filebeat":{"pid":134,"alive":true,"restart_count":0,"seconds_since_last_restart":-1},"esqueues_me":{},"system":{"java_version":"1.8.0_252","jruby_version":"9.2.13.0","os_name":"Linux","os_version":"5.4.0-54-generic"}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json;charset=utf-8
+      ETag:
+      - W/"6115c2e4940f91264c10b0639bd40710"
+      Server:
+      - Jetty(9.4.33.v20201020)
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding, User-Agent
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - ec81436b-2c78-4374-a4c0-1fa9c89866d1
+      X-Runtime:
+      - '0.033051'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/client/enterprise_search/cassettes/test_get_stats.yaml
+++ b/tests/client/enterprise_search/cassettes/test_get_stats.yaml
@@ -1,0 +1,82 @@
+interactions:
+- request:
+    body: null
+    headers:
+      authorization:
+      - Basic ZWxhc3RpYzpjaGFuZ2VtZQ==
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+    method: GET
+    uri: http://localhost:3002/api/ent/v1/internal/stats
+  response:
+    body:
+      string: '{"app":{"pid":6,"start":"2021-01-27T20:34:48+00:00","end":"2021-01-27T20:35:48+00:00","metrics":{"timers.actastic.relation.search":{"sum":214.88393805339,"max":7.693164021475241,"mean":3.6421006449727122},"timers.cron.local.cron-keep_filebeat_alive.total_job_time":{"sum":23.110500012990087,"max":23.110500012990087,"mean":23.110500012990087},"timers.cron.local.cron-cleanup_heartbeat_index.total_job_time":{"sum":27.537045010831207,"max":27.537045010831207,"mean":27.537045010831207},"timers.cron.local.cron-refresh_elasticsearch_license.total_job_time":{"sum":31.15287100081332,"max":31.15287100081332,"mean":31.15287100081332},"timers.actastic.relation.document_count":{"sum":9.87388999783434,"max":2.1980470046401024,"mean":1.974777999566868},"timers.http.request.all":{"sum":281.4068794250488,"max":232.64312744140625,"mean":70.3517198562622},"timers.http.request.302":{"sum":32.675743103027344,"max":17.500877380371094,"mean":16.337871551513672},"timers.http.request.401":{"sum":16.088008880615234,"max":16.088008880615234,"mean":16.088008880615234},"timers.http.request.200":{"sum":232.64312744140625,"max":232.64312744140625,"mean":232.64312744140625},"counters.http.request.all":4,"counters.http.request.302":2,"counters.http.request.401":1,"counters.http.request.200":1}},"queues":{"connectors":{"pending":0},"document_destroyer":{"pending":0},"engine_destroyer":{"pending":0},"index_adder":{"pending":0},"indexed_doc_remover":{"pending":0},"mailer":{"pending":0},"refresh_document_counts":{"pending":0},"reindexer":{"pending":0},"schema_updater":{"pending":0},"seed_sample_engine":{"pending":0},"workplace_search":{"pending":0},"failed":[]},"connectors":{"alive":true,"pool":{"extract_worker_pool":{"running":true,"queue_depth":0,"size":8,"busy":1,"idle":7,"total_scheduled":1911,"total_completed":1910},"subextract_worker_pool":{"running":true,"queue_depth":0,"size":0,"busy":0,"idle":0,"total_scheduled":0,"total_completed":0},"publish_worker_pool":{"running":true,"queue_depth":0,"size":0,"busy":0,"idle":0,"total_scheduled":0,"total_completed":0},"status_update_worker_pool":{"running":true,"queue_depth":0,"size":0,"busy":0,"idle":0,"total_scheduled":0,"total_completed":0}},"job_store":{"waiting":0,"working":0,"job_types":{"full":0,"incremental":0,"delete":0,"permissions":0}}}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json;charset=utf-8
+      ETag:
+      - W/"797d682bdbd532571cb49ebd0ff1b313"
+      Server:
+      - Jetty(9.4.33.v20201020)
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding, User-Agent
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - c8f14630-5b1b-49fd-b39e-5c0a8617af83
+      X-Runtime:
+      - '0.058923'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      authorization:
+      - Basic ZWxhc3RpYzpjaGFuZ2VtZQ==
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+    method: GET
+    uri: http://localhost:3002/api/ent/v1/internal/stats?include=connectors,queues
+  response:
+    body:
+      string: '{"connectors":{"alive":true,"pool":{"extract_worker_pool":{"running":true,"queue_depth":0,"size":8,"busy":1,"idle":7,"total_scheduled":1911,"total_completed":1910},"subextract_worker_pool":{"running":true,"queue_depth":0,"size":0,"busy":0,"idle":0,"total_scheduled":0,"total_completed":0},"publish_worker_pool":{"running":true,"queue_depth":0,"size":0,"busy":0,"idle":0,"total_scheduled":0,"total_completed":0},"status_update_worker_pool":{"running":true,"queue_depth":0,"size":0,"busy":0,"idle":0,"total_scheduled":0,"total_completed":0}},"job_store":{"waiting":0,"working":0,"job_types":{"full":0,"incremental":0,"delete":0,"permissions":0}}},"queues":{"connectors":{"pending":0},"document_destroyer":{"pending":0},"engine_destroyer":{"pending":0},"index_adder":{"pending":0},"indexed_doc_remover":{"pending":0},"mailer":{"pending":0},"refresh_document_counts":{"pending":0},"reindexer":{"pending":0},"schema_updater":{"pending":0},"seed_sample_engine":{"pending":0},"workplace_search":{"pending":0},"failed":[]}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json;charset=utf-8
+      ETag:
+      - W/"e262a6c051b70a3f99cb1cf9a643d3f8"
+      Server:
+      - Jetty(9.4.33.v20201020)
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding, User-Agent
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - 5e674fad-3c40-4bbb-92ad-153345dd4c27
+      X-Runtime:
+      - '0.060609'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/client/enterprise_search/cassettes/test_get_version.yaml
+++ b/tests/client/enterprise_search/cassettes/test_get_version.yaml
@@ -1,0 +1,46 @@
+interactions:
+- request:
+    body: null
+    headers:
+      authorization:
+      - Basic ZWxhc3RpYzpjaGFuZ2VtZQ==
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+    method: GET
+    uri: http://localhost:3002/api/ent/v1/internal/health
+  response:
+    body:
+      string: '{"name":"f1b653d1bbd8","version":{"number":"7.12.0","build_hash":"3a6edf8029dd285b60f1a6d63c741f46df7f195f","build_date":"2021-01-06T15:24:44Z"},"jvm":{"gc":{"collection_count":43,"collection_time":2360,"garbage_collectors":{"PS
+        Scavenge":{"collection_count":38,"collection_time":1095},"PS MarkSweep":{"collection_count":5,"collection_time":1265}}},"pid":6,"uptime":5124162,"memory_usage":{"heap_init":1073741824,"heap_used":593947736,"heap_committed":1803026432,"heap_max":1908932608,"object_pending_finalization_count":0,"non_heap_init":2555904,"non_heap_committed":365912064},"memory_pools":["Code
+        Cache","Metaspace","Compressed Class Space","PS Eden Space","PS Survivor Space","PS
+        Old Gen"],"threads":{"thread_count":39,"peak_thread_count":45,"total_started_thread_count":157,"daemon_thread_count":12},"vm_version":"25.252-b09","vm_vendor":"AdoptOpenJDK","vm_name":"OpenJDK
+        64-Bit Server VM"},"filebeat":{"pid":134,"alive":true,"restart_count":0,"seconds_since_last_restart":-1},"esqueues_me":{},"system":{"java_version":"1.8.0_252","jruby_version":"9.2.13.0","os_name":"Linux","os_version":"5.4.0-54-generic"}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json;charset=utf-8
+      ETag:
+      - W/"961984a91b3f0e331c885bd0299bc298"
+      Server:
+      - Jetty(9.4.33.v20201020)
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding, User-Agent
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - a3293f60-0b41-4b32-af40-9d3f164bfda7
+      X-Runtime:
+      - '0.017693'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/client/enterprise_search/test_enterprise_search.py
+++ b/tests/client/enterprise_search/test_enterprise_search.py
@@ -1,0 +1,90 @@
+#  Licensed to Elasticsearch B.V. under one or more contributor
+#  license agreements. See the NOTICE file distributed with
+#  this work for additional information regarding copyright
+#  ownership. Elasticsearch B.V. licenses this file to you under
+#  the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+import pytest
+
+from elastic_enterprise_search import EnterpriseSearch
+
+
+@pytest.fixture()
+def enterprise_search():
+    yield EnterpriseSearch("http://localhost:3002", http_auth=("elastic", "changeme"))
+
+
+@pytest.mark.vcr()
+def test_get_stats(enterprise_search):
+    resp = enterprise_search.get_stats()
+    assert resp.status == 200
+    assert sorted(resp.keys()) == ["app", "connectors", "queues"]
+
+    resp = enterprise_search.get_stats(include=["connectors", "queues"])
+    assert resp.status == 200
+    assert sorted(resp.keys()) == ["connectors", "queues"]
+
+
+@pytest.mark.vcr()
+def test_get_health(enterprise_search):
+    resp = enterprise_search.get_health()
+    assert resp.status == 200
+    assert sorted(resp.keys()) == [
+        "esqueues_me",
+        "filebeat",
+        "jvm",
+        "name",
+        "system",
+        "version",
+    ]
+    assert resp["version"] == {
+        "build_date": "2021-01-06T15:24:44Z",
+        "build_hash": "3a6edf8029dd285b60f1a6d63c741f46df7f195f",
+        "number": "7.12.0",
+    }
+
+
+@pytest.mark.vcr()
+def test_get_version(enterprise_search):
+    resp = enterprise_search.get_health()
+    assert resp.status == 200
+    assert sorted(resp.keys()) == [
+        "esqueues_me",
+        "filebeat",
+        "jvm",
+        "name",
+        "system",
+        "version",
+    ]
+    assert resp["version"] == {
+        "build_date": "2021-01-06T15:24:44Z",
+        "build_hash": "3a6edf8029dd285b60f1a6d63c741f46df7f195f",
+        "number": "7.12.0",
+    }
+
+
+@pytest.mark.vcr()
+def test_get_and_put_read_only(enterprise_search):
+    http_auth = ("elastic", "changeme")
+    resp = enterprise_search.put_read_only(body={"enabled": True}, http_auth=http_auth)
+    assert resp.status == 200
+    assert resp == {"enabled": True}
+
+    resp = enterprise_search.get_read_only(http_auth=http_auth)
+    assert resp.status == 200
+    assert resp == {"enabled": True}
+
+    resp = enterprise_search.put_read_only(body={"enabled": False}, http_auth=http_auth)
+    assert resp.status == 200
+    assert resp == {"enabled": False}

--- a/utils/generator/generate-api.py
+++ b/utils/generator/generate-api.py
@@ -260,6 +260,10 @@ class API:
         return "requestBody" in self.spec
 
     @property
+    def body_param_name(self) -> str:
+        return to_python_param(self.spec.get("x-codegen-request-body-name", "body"))
+
+    @property
     def body_required(self) -> bool:
         # TODO: OpenAPI actually should default to 'False' but
         # the Enterprise Search specs seem to default to 'True' so

--- a/utils/generator/templates/api
+++ b/utils/generator/templates/api
@@ -3,7 +3,7 @@
         {% for param in api.required_params %}
         {{ param.param_name }},
         {% endfor %}{% if api.has_body %}
-        body{% if not api.body_required %}=None{% endif %},
+        {{ api.body_param_name }}{% if not api.body_required %}=None{% endif %},
         {% endif %}{% for param in api.optional_params %}
         {{ param.param_name }}=None,
         {% endfor %}
@@ -19,7 +19,7 @@
         `<{{ api.docs_url }}>`_
 {% endif %}{% if api.all_params|list|length or api.has_body %}{% for param in api.all_params %}
         {% filter wordwrap(72, wrapstring="\n            ") %}:arg {{ param.param_name }}: {{ param.description }}{% endfilter %}{% endfor %}{% if api.has_body %}
-        :arg body: {{ api.body_description }}{% endif %}{% endif %}
+        :arg {{ api.body_param_name }}: {{ api.body_description }}{% endif %}{% endif %}
         :arg params: Additional query params to send with the request
         :arg headers: Additional headers to send with the request
         :arg http_auth: Access token or HTTP basic auth username
@@ -53,7 +53,7 @@
                 {% endif %}
             {% endfor %}){% else %}"{% for part in api.path_parts %}/{{ part }}{% endfor %}"{% endif %},
             {% if api.has_body %}
-            body=body,
+            body={{ api.body_param_name }},
             {% endif %}
             params=params,
             headers=headers,


### PR DESCRIPTION
Minor change to use the `x-codegen-request-body-name` of APIs instead of generic `body`. This isn't available on APIs that have complex bodies, those will need to be handled by adding additional parameters.