### PR TITLE
Remove elasticsearch-oss Docker container from CI

### DIFF
--- a/.ci/functions/imports.sh
+++ b/.ci/functions/imports.sh
@@ -18,7 +18,7 @@ require_stack_version
 if [[ -z $es_node_name ]]; then
   # only set these once
   set -euo pipefail
-  export TEST_SUITE=${TEST_SUITE-oss}
+  export TEST_SUITE=${TEST_SUITE-free}
   export RUNSCRIPTS=${RUNSCRIPTS-}
   export DETACH=${DETACH-false}
   export CLEANUP=${CLEANUP-false}
@@ -27,8 +27,7 @@ if [[ -z $es_node_name ]]; then
   export elastic_password=changeme
   export elasticsearch_image=elasticsearch
   export elasticsearch_url=https://elastic:${elastic_password}@${es_node_name}:9200
-  if [[ $TEST_SUITE != "xpack" ]]; then
-    export elasticsearch_image=elasticsearch-${TEST_SUITE}
+  if [[ $TEST_SUITE != "platinum" ]]; then
     export elasticsearch_url=http://${es_node_name}:9200
   fi
   export external_elasticsearch_url=${elasticsearch_url/$es_node_name/localhost}

--- a/.ci/run-elasticsearch.sh
+++ b/.ci/run-elasticsearch.sh
@@ -4,16 +4,17 @@
 # to form a cluster suitable for running the REST API tests.
 #
 # Export the STACK_VERSION variable, eg. '8.0.0-SNAPSHOT'.
-# Export the TEST_SUITE variable, eg. 'oss' or 'xpack' defaults to 'oss'.
+# Export the TEST_SUITE variable, eg. 'free' or 'platinum' defaults to 'free'.
 # Export the NUMBER_OF_NODES variable to start more than 1 node
 
-# Version 1.1.0
+# Version 1.2.0
 # - Initial version of the run-elasticsearch.sh script
 # - Deleting the volume should not dependent on the container still running
 # - Fixed `ES_JAVA_OPTS` config
 # - Moved to STACK_VERSION and TEST_VERSION
 # - Refactored into functions and imports
 # - Support NUMBER_OF_NODES
+# - Added 5 retries on docker pull for fixing transient network errors
 
 script_path=$(dirname $(realpath -s $0))
 source $script_path/functions/imports.sh
@@ -38,7 +39,7 @@ environment=($(cat <<-END
   --env repositories.url.allowed_urls=http://snapshot.test*
 END
 ))
-if [[ "$TEST_SUITE" == "xpack" ]]; then
+if [[ "$TEST_SUITE" == "platinum" ]]; then
   environment+=($(cat <<-END
     --env ELASTIC_PASSWORD=$elastic_password
     --env xpack.license.self_generated.type=trial
@@ -63,18 +64,18 @@ END
 fi
 
 cert_validation_flags=""
-if [[ "$TEST_SUITE" == "xpack" ]]; then
+if [[ "$TEST_SUITE" == "platinum" ]]; then
   cert_validation_flags="--insecure --cacert /usr/share/elasticsearch/config/certs/ca.crt --resolve ${es_node_name}:443:127.0.0.1"
 fi
 
 # Pull the container, retry on failures up to 5 times with
 # short delays between each attempt. Fixes most transient network errors.
-set -x
 docker_pull_attempts=0
 until [ "$docker_pull_attempts" -ge 5 ]
 do
    docker pull docker.elastic.co/elasticsearch/"$elasticsearch_container" && break
    docker_pull_attempts=$((docker_pull_attempts+1))
+   echo "Failed to pull image, retrying in 10 seconds (retry $docker_pull_attempts/5)..."
    sleep 10
 done
 

--- a/.ci/run-enterprise-search.sh
+++ b/.ci/run-enterprise-search.sh
@@ -29,6 +29,7 @@ until [ "$docker_pull_attempts" -ge 5 ]
 do
    docker pull docker.elastic.co/enterprise-search/enterprise-search:"$STACK_VERSION" && break
    docker_pull_attempts=$((docker_pull_attempts+1))
+   echo "Failed to pull image, retrying in 10 seconds (retry $docker_pull_attempts/5)..."
    sleep 10
 done
 
@@ -40,6 +41,7 @@ docker run \
   --env "elasticsearch.host=$elasticsearch_url" \
   --env "elasticsearch.username=elastic" \
   --env "elasticsearch.password=$elastic_password" \
+  --env "ENT_SEARCH_DEFAULT_PASSWORD=$elastic_password" \
   --env "secret_management.encryption_keys=[$APP_SEARCH_SECRET_SESSION_KEY]" \
   --env "enterprise_search.listen_port=$http_port" \
   --env "log_level=info" \

--- a/.ci/run-tests
+++ b/.ci/run-tests
@@ -5,12 +5,12 @@
 # - Add `$RUNSCRIPTS` env var for running Elasticsearch dependent products
 script_path=$(dirname $(realpath -s $0))
 source $script_path/functions/imports.sh
-
-# Enterprise Search requires a licensed Elasticsearch instance
-export TEST_SUITE=xpack
-export RUNSCRIPTS=enterprise-search
-
 set -euo pipefail
+
+# Default environment variables
+export PYTHON_VERSION=${PYTHON_VERSION-3.9}
+export TEST_SUITE=platinum
+export RUNSCRIPTS=enterprise-search
 
 echo -e "\033[1m>>>>> Start [$STACK_VERSION container] >>>>>>>>>>>>>>>>>>>>>>>>>>>>>\033[0m"
 DETACH=true bash .ci/run-elasticsearch.sh


### PR DESCRIPTION
The `elasticsearch/elasticsearch-oss` Docker container isn't being published on `docker.elastic.co` after the relicensing so we need to use the `elasticsearch/elasticsearch` container instead.