### PR TITLE
Removed forward of non accepted parameters to transport constructor

### DIFF
--- a/elastic_enterprise_search/_sync/client/_base.py
+++ b/elastic_enterprise_search/_sync/client/_base.py
@@ -80,12 +80,6 @@ class BaseClient:
     ):
         if _transport is None:
             transport_kwargs = {}
-            if connections_per_node is not DEFAULT:
-                transport_kwargs["connections_per_node"] = connections_per_node
-            if http_compress is not DEFAULT:
-                transport_kwargs["http_compress"] = http_compress
-            if verify_certs is not DEFAULT:
-                transport_kwargs["verify_certs"] = verify_certs
             if node_class is not DEFAULT:
                 transport_kwargs["node_class"] = node_class
             if dead_node_backoff_factor is not DEFAULT:


### PR DESCRIPTION
The transport class does not accept the parameters in its constructor and it is passed in the node_configs instead.

The transport class constructor does not accept the following parameters :
- connections_per_node
- http_compress
- verify_certs

The passing of these parameters causes TypeErrors as the constructor receives unexpected keyword arguments.

These parameters are now passed through the node_configs parameter instead.