### PR TITLE
Add release notes for 8.5.0

### DIFF
--- a/docs/guide/release-notes/8-5-0.asciidoc
+++ b/docs/guide/release-notes/8-5-0.asciidoc
@@ -1,0 +1,4 @@
+[[release-notes-8-5-0]]
+=== 8.5.0 Release Notes
+
+Client is compatible with Elastic Enterprise Search 8.5.0

--- a/docs/guide/release-notes/index.asciidoc
+++ b/docs/guide/release-notes/index.asciidoc
@@ -1,33 +1,12 @@
 [[release_notes]]
 == Release Notes
 
-[discrete]
-=== 8.x
-
+* <<release-notes-8-4-0, 8.5.0 Release Notes>>
 * <<release-notes-8-4-0, 8.4.0 Release Notes>>
 * <<release-notes-8-3-0, 8.3.0 Release Notes>>
 * <<release-notes-8-2-0, 8.2.0 Release Notes>>
 
-[discrete]
-=== 7.x
-
-* <<release-notes-7-17-0, 7.17.0 Release Notes>>
-* <<release-notes-7-16-0, 7.16.0 Release Notes>>
-* <<release-notes-7-15-0, 7.15.0 Release Notes>>
-* <<release-notes-7-14-0, 7.14.0 Release Notes>>
-* <<release-notes-7-13-0, 7.13.0 Release Notes>>
-* <<release-notes-7-12-0, 7.12.0 Release Notes>>
-* <<release-notes-7-11-0, 7.11.0 Release Notes>>
-* <<release-notes-7-10-0, 7.10.0-beta1 Release Notes>>
-
+include::8-5-0.asciidoc[]
 include::8-4-0.asciidoc[]
 include::8-3-0.asciidoc[]
 include::8-2-0.asciidoc[]
-include::7-17-0.asciidoc[]
-include::7-16-0.asciidoc[]
-include::7-15-0.asciidoc[]
-include::7-14-0.asciidoc[]
-include::7-13-0.asciidoc[]
-include::7-12-0.asciidoc[]
-include::7-11-0.asciidoc[]
-include::7-10-0.asciidoc[]


### PR DESCRIPTION
Also removes 7.x release notes from the page on 8.x docs. Can still be viewed in the 7.x branch of docs.