### PR TITLE
Initialize app search client with bearer_auth flag

### DIFF
--- a/docs/guide/app-search-api.asciidoc
+++ b/docs/guide/app-search-api.asciidoc
@@ -25,7 +25,7 @@ from elastic_enterprise_search import AppSearch
 
 app_search = AppSearch(
     "http://localhost:3002",
-    http_auth="private-..."
+    bearer_auth="private-..."
 )
 # Now call API methods
 app_search.search(...)

--- a/docs/guide/release-notes/8-4-0.asciidoc
+++ b/docs/guide/release-notes/8-4-0.asciidoc
@@ -1,0 +1,12 @@
+[[release-notes-8-4-0]]
+=== 8.4.0 Release Notes
+
+[discrete]
+==== Added
+
+- Added the `app_search.search_es_search` API method.
+
+[discrete]
+==== Changed
+
+- Changed URL parsing to use default ports for `http` and `https` schemes instead of raising an error.

--- a/docs/guide/release-notes/8-5-0.asciidoc
+++ b/docs/guide/release-notes/8-5-0.asciidoc
@@ -1,0 +1,4 @@
+[[release-notes-8-5-0]]
+=== 8.5.0 Release Notes
+
+Client is compatible with Elastic Enterprise Search 8.5.0

--- a/docs/guide/release-notes/index.asciidoc
+++ b/docs/guide/release-notes/index.asciidoc
@@ -4,6 +4,7 @@
 [discrete]
 === 8.x
 
+* <<release-notes-8-4-0, 8.4.0 Release Notes>>
 * <<release-notes-8-3-0, 8.3.0 Release Notes>>
 * <<release-notes-8-2-0, 8.2.0 Release Notes>>
 
@@ -19,6 +20,7 @@
 * <<release-notes-7-11-0, 7.11.0 Release Notes>>
 * <<release-notes-7-10-0, 7.10.0-beta1 Release Notes>>
 
+include::8-4-0.asciidoc[]
 include::8-3-0.asciidoc[]
 include::8-2-0.asciidoc[]
 include::7-17-0.asciidoc[]

--- a/docs/guide/release-notes/index.asciidoc
+++ b/docs/guide/release-notes/index.asciidoc
@@ -1,33 +1,12 @@
 [[release_notes]]
 == Release Notes
 
-[discrete]
-=== 8.x
-
+* <<release-notes-8-4-0, 8.5.0 Release Notes>>
 * <<release-notes-8-4-0, 8.4.0 Release Notes>>
 * <<release-notes-8-3-0, 8.3.0 Release Notes>>
 * <<release-notes-8-2-0, 8.2.0 Release Notes>>
 
-[discrete]
-=== 7.x
-
-* <<release-notes-7-17-0, 7.17.0 Release Notes>>
-* <<release-notes-7-16-0, 7.16.0 Release Notes>>
-* <<release-notes-7-15-0, 7.15.0 Release Notes>>
-* <<release-notes-7-14-0, 7.14.0 Release Notes>>
-* <<release-notes-7-13-0, 7.13.0 Release Notes>>
-* <<release-notes-7-12-0, 7.12.0 Release Notes>>
-* <<release-notes-7-11-0, 7.11.0 Release Notes>>
-* <<release-notes-7-10-0, 7.10.0-beta1 Release Notes>>
-
+include::8-5-0.asciidoc[]
 include::8-4-0.asciidoc[]
 include::8-3-0.asciidoc[]
 include::8-2-0.asciidoc[]
-include::7-17-0.asciidoc[]
-include::7-16-0.asciidoc[]
-include::7-15-0.asciidoc[]
-include::7-14-0.asciidoc[]
-include::7-13-0.asciidoc[]
-include::7-12-0.asciidoc[]
-include::7-11-0.asciidoc[]
-include::7-10-0.asciidoc[]


### PR DESCRIPTION
`http_auth` gives warning message:
DeprecationWarning: The 'http_auth' parameter is deprecated. Use 'basic_auth' or 'bearer_auth' parameters instead