### PR TITLE
[Docs] Fix typo in subheading

### DIFF
--- a/docs/guide/app-search-api.asciidoc
+++ b/docs/guide/app-search-api.asciidoc
@@ -604,7 +604,7 @@ app_search.list_curations(
 )
 ---------------
 
-==== Get Curation
+==== Delete Curation
 
 [source,python]
 ---------------


### PR DESCRIPTION
Drive-by typo spot 😃 

<img width="1331" alt="Screenshot 2023-01-05 at 12 58 07" src="https://user-images.githubusercontent.com/32779855/210775254-6a024f31-c6d3-456a-a796-8bac8005b572.png">
