### PR TITLE
Initialize app search client with bearer_auth flag

### DIFF
--- a/docs/guide/app-search-api.asciidoc
+++ b/docs/guide/app-search-api.asciidoc
@@ -25,7 +25,7 @@ from elastic_enterprise_search import AppSearch
 
 app_search = AppSearch(
     "http://localhost:3002",
-    http_auth="private-..."
+    bearer_auth="private-..."
 )
 # Now call API methods
 app_search.search(...)


### PR DESCRIPTION
`http_flag` gives warning message:
DeprecationWarning: The 'http_auth' parameter is deprecated. Use 'basic_auth' or 'bearer_auth' parameters instead
as discussed in #158 