### PR TITLE
Construct body with 'boosts' according to the current API

### DIFF
--- a/elastic_enterprise_search/_sync/client/app_search.py
+++ b/elastic_enterprise_search/_sync/client/app_search.py
@@ -2361,7 +2361,7 @@ class AppSearch(BaseClient):
         if analytics is not None:
             __body["analytics"] = analytics
         if boost is not None:
-            __body["boost"] = boost
+            __body["boosts"] = boost
         if current_page is not None:
             __body.setdefault("page", {})
             __body["page"]["current"] = current_page
@@ -2471,7 +2471,7 @@ class AppSearch(BaseClient):
         if analytics is not None:
             __body["analytics"] = analytics
         if boost is not None:
-            __body["boost"] = boost
+            __body["boosts"] = boost
         if current_page is not None:
             __body.setdefault("page", {})
             __body["page"]["current"] = current_page


### PR DESCRIPTION
See documentation here: https://www.elastic.co/guide/en/app-search/8.9/relevance-tuning-guide.html#relevance-tuning-guide-weights-and-boosts-boosts-via-api

The current bug can be reproduced with:

```
>>> from elastic_enterprise_search import AppSearch
>>> app_search_client = AppSearch(
...     HOST,
...     bearer_auth=API_KEY,
... )
>>> query="robot"
>>> 
>>> results = app_search_client.search(
...     engine_name=ENGINE, query=query, page_size=10
... )
>>> len(results['results'])
10
>>> boosts = {
...     "num_interactions": [
...         {
...             "type": "functional",
...             "function": "logarithmic",
...             "operation": "add",
...             "factor": 3.5,
...         }
...     ]
... }
>>> 
>>> results2 = app_search_client.search(
...     engine_name=ENGINE, query=query, page_size=10, boost=boosts
... )
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/homebrew/lib/python3.11/site-packages/elastic_enterprise_search/_utils.py", line 454, in wrapped
    return api(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/elastic_enterprise_search/_sync/client/app_search.py", line 2384, in search
    return self.perform_request(  # type: ignore[return-value]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/elastic_enterprise_search/_sync/client/_base.py", line 249, in perform_request
    raise _HTTP_EXCEPTIONS.get(resp.meta.status, ApiError)(
elastic_enterprise_search.exceptions.BadRequestError: [400] {'errors': ['Options contains invalid key: boost']}
>>> 
```

With this change, the [bug](https://github.com/elastic/enterprise-search-python/issues/151) is resolved and AppSearch WAI.

```
>>> boosts = {
...     "num_interactions": [
...         {
...             "type": "functional",
...             "function": "logarithmic",
...             "operation": "add",
...             "factor": 3.5,
...         }
...     ]
... }
>>> 
>>> results2 = app_search_client.search(
...     engine_name=ENGINE, query=query, page_size=10, boost=boosts
... )
>>> len(results2['results'])
10
```

Maybe consider renaming the kwarg to `boosts` but hopefully in a follow up PR so I can be unblocked. Thank you!