### PR TITLE
Fix CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,7 +12,7 @@ steps:
           - "3.10"
           - "3.11"
         stack_version:
-          - "8.10.0-SNAPSHOT"
+          - "8.11.0-SNAPSHOT"
     env:
       PYTHON_VERSION: "{{ matrix.python }}"
       STACK_VERSION: "{{ matrix.stack_version }}"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,6 @@
 ---
 steps:
-  - label: ":python: :elastic-enterprise-search:"
+  - label: ":python: {{ matrix.python }} :elastic-enterprise-search: {{ matrix.stack_version }}"
     agents:
       provider: gcp
     matrix:

--- a/.buildkite/run-repository.sh
+++ b/.buildkite/run-repository.sh
@@ -56,4 +56,4 @@ docker run \
   -e ENTERPRISE_SEARCH_PASSWORD="$elastic_password" \
   -v "$(pwd)/junit:/junit" \
   elastic/enterprise-search-python \
-  bash -c "nox -s test-$PYTHON_VERSION; [ -f ./junit/${BUILDKITE_JOB_ID:-}-junit.xml ] && mv ./junit/${BUILDKITE_JOB_ID:-}-junit.xml /junit || echo 'No JUnit artifact found'"
+  bash -c "set -euo pipefail; nox -s test-$PYTHON_VERSION; [ -f ./junit/${BUILDKITE_JOB_ID:-}-junit.xml ] && mv ./junit/${BUILDKITE_JOB_ID:-}-junit.xml /junit || echo 'No JUnit artifact found'"

--- a/noxfile.py
+++ b/noxfile.py
@@ -68,6 +68,7 @@ def tests_impl(session):
         "git+https://github.com/elastic/elastic-transport-python", silent=False
     )
     session.install(".[develop]", silent=False)
+    session.install("urllib3<2", silent=False)
     session.run(
         "pytest",
         f"--junitxml={junit_xml}",

--- a/noxfile.py
+++ b/noxfile.py
@@ -68,7 +68,7 @@ def tests_impl(session):
         "git+https://github.com/elastic/elastic-transport-python", silent=False
     )
     session.install(".[develop]", silent=False)
-    session.install("urllib3<2", silent=False)
+    session.install("elastic-transport<8.10", silent=False)
     session.run(
         "pytest",
         f"--junitxml={junit_xml}",

--- a/noxfile.py
+++ b/noxfile.py
@@ -65,10 +65,11 @@ def tests_impl(session):
         )
 
     session.install(
-        "git+https://github.com/elastic/elastic-transport-python", silent=False
+        ".[develop]",
+        # https://github.com/elastic/elastic-transport-python/pull/121 broke the VCRpy cassettes on Python 3.10+
+        "elastic-transport<8.10",
+        silent=False,
     )
-    session.install(".[develop]", silent=False)
-    session.install("elastic-transport<8.10", silent=False)
     session.run(
         "pytest",
         f"--junitxml={junit_xml}",

--- a/noxfile.py
+++ b/noxfile.py
@@ -64,8 +64,10 @@ def tests_impl(session):
             "junit/enterprise-search-python-junit.xml",
         )
 
-    session.install("git+https://github.com/elastic/elastic-transport-python")
-    session.install(".[develop]")
+    session.install(
+        "git+https://github.com/elastic/elastic-transport-python", silent=False
+    )
+    session.install(".[develop]", silent=False)
     session.run(
         "pytest",
         f"--junitxml={junit_xml}",

--- a/setup.py
+++ b/setup.py
@@ -39,16 +39,6 @@ packages = [
     if package.startswith("elastic_enterprise_search")
 ]
 
-# Allow pre-releases of elastic-transport if the
-# package itself is a pre-release, otherwise only
-# allow stable releases to avoid disrupting stable versions.
-elastic_transport_required = "elastic-transport>=8.4,<9"
-if not re.match(r"^[0-9.]+$", version):
-    # Adds '.dev' to the end of every version number.
-    elastic_transport_required = re.sub(
-        r"([0-9.]+)([^0-9.]|$)", r"\1.dev\2", elastic_transport_required
-    )
-
 setup(
     name="elastic-enterprise-search",
     description=(
@@ -70,7 +60,7 @@ setup(
     },
     packages=packages,
     install_requires=[
-        elastic_transport_required,
+        "elastic-transport>=8.4,<9",
         "PyJWT>=1,<3",
         "python-dateutil>=2,<3",
         "six>=1.12",


### PR DESCRIPTION
This required pinning elastic-transport-python to <8.10 in the tests, as the urllib3 patching done in elastic-transport-python is incompatible with the patching done by VCRPy. (I haven't looked at the details.)